### PR TITLE
Add permessage-deflate support 

### DIFF
--- a/common/src/main/java/com/github/czyzby/websocket/impl/NvWebSocket.java
+++ b/common/src/main/java/com/github/czyzby/websocket/impl/NvWebSocket.java
@@ -5,6 +5,7 @@ import com.github.czyzby.websocket.data.WebSocketCloseCode;
 import com.github.czyzby.websocket.data.WebSocketException;
 import com.github.czyzby.websocket.data.WebSocketState;
 import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketExtension;
 import com.neovisionaries.ws.client.WebSocketFactory;
 
 import java.net.SocketException;
@@ -27,6 +28,7 @@ public class NvWebSocket extends AbstractWebSocket {
             dispose();
             final WebSocket currentWebSocket = webSocket = webSocketFactory.createSocket(getUrl());
             currentWebSocket.addListener(new NvWebSocketListener(this));
+            if (useDeflate) currentWebSocket.addExtension(WebSocketExtension.PERMESSAGE_DEFLATE);
             currentWebSocket.connectAsynchronously();
         } catch (final Throwable exception) {
             throw new WebSocketException("Unable to connect.", exception);

--- a/core/src/main/java/com/github/czyzby/websocket/WebSocket.java
+++ b/core/src/main/java/com/github/czyzby/websocket/WebSocket.java
@@ -124,4 +124,9 @@ public interface WebSocket {
      * @param reason closing reason. Optional.
      * @throws WebSocketException if unable to close the connection. */
     void close(int closeCode, String reason) throws WebSocketException;
+
+    /** @param permessageDeflate if true, enable the permessage deflate extension for this websocket
+     * NOTE: This has no effect in browsers.
+     * */
+    void setPerMessageDeflate(boolean permessageDeflate);
 }

--- a/core/src/main/java/com/github/czyzby/websocket/impl/AbstractWebSocket.java
+++ b/core/src/main/java/com/github/czyzby/websocket/impl/AbstractWebSocket.java
@@ -18,6 +18,7 @@ public abstract class AbstractWebSocket implements WebSocket {
     private final String url;
     private final Array<WebSocketListener> listeners = new Array<WebSocketListener>(2); // Default 16 is likely too big.
     protected boolean useTcpNoDelay = true;
+    protected boolean useDeflate;
     protected boolean verifyHostname = false;
     private Serializer serializer = WebSockets.DEFAULT_SERIALIZER;
     private boolean serializeAsString;
@@ -270,4 +271,9 @@ public abstract class AbstractWebSocket implements WebSocket {
     public void close(final int closeCode) throws WebSocketException {
         close(closeCode, null);
     }
+
+    @Override
+    public void setPerMessageDeflate(boolean permessageDeflate){
+        useDeflate=permessageDeflate;
+    };
 }


### PR DESCRIPTION
Adds support for the permessage-deflate extension outside of web browsers. As discussed in #13 